### PR TITLE
Mark as EOL

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+    "end-of-life": "This application no longer receives updates from its developers."
+}


### PR DESCRIPTION
It's had no updates for 3 years, and upstream has recommended switching to Kraken Office (though that is also unmaintained, and does not have a flatpak).